### PR TITLE
Swap http_send_status for http_response_code

### DIFF
--- a/inc/handle-artwork.php
+++ b/inc/handle-artwork.php
@@ -23,7 +23,7 @@ while (ob_get_level()) {
 }
 
 if ( ! isset($_GET['artist'])) {
-    http_send_status(404);
+    http_response_code(404);
     exit;
 }
 

--- a/panel/api.php
+++ b/panel/api.php
@@ -76,7 +76,7 @@ try {
 
     }
 
-    http_send_status(404);
+    http_response_code(404);
     die("404 - Not Found");
 
 } catch (Throwable|Exception $e) {
@@ -88,7 +88,7 @@ try {
     $pawtunes->writeLog('panel_errors', $e->getMessage());
     $pawtunes->writeLog('panel_errors', $e->getTraceAsString());
 
-    http_send_status(500);
+    http_response_code(500);
     die("500 - Internal Server Error");
 
 }

--- a/panel/lib/API/Artwork.php
+++ b/panel/lib/API/Artwork.php
@@ -31,7 +31,7 @@ class Artwork extends Base
 
         $art = $this->pawtunes->getArtwork($text, '', '', $skip);
         if ( ! $art) {
-            http_send_status(404);
+            http_response_code(404);
             exit;
         }
 


### PR DESCRIPTION
## Summary
- use PHP `http_response_code` instead of the `http_send_status` function

## Testing
- `php -l inc/handle-artwork.php`
- `php -l panel/api.php`
- `php -l panel/lib/API/Artwork.php`

------
https://chatgpt.com/codex/tasks/task_e_68722ca9e064832580a75c1ea1910259